### PR TITLE
Feature/add web exchange bind exception handler

### DIFF
--- a/src/main/kotlin/json/delivery/socialnetworkservice/app/api/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/json/delivery/socialnetworkservice/app/api/GlobalExceptionHandler.kt
@@ -29,7 +29,7 @@ class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(Exception::class)
-    fun handleRunTimeException(ex: Exception): ResponseEntity<String> {
+    fun handleGlobalException(ex: Exception): ResponseEntity<String> {
         return ResponseEntity("An unexpected error occurred: ${ex.message}", HttpStatus.INTERNAL_SERVER_ERROR)
     }
 }

--- a/src/main/kotlin/json/delivery/socialnetworkservice/app/api/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/json/delivery/socialnetworkservice/app/api/GlobalExceptionHandler.kt
@@ -5,6 +5,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.bind.support.WebExchangeBindException
 
 @RestControllerAdvice
 class GlobalExceptionHandler {
@@ -14,13 +15,21 @@ class GlobalExceptionHandler {
         return ResponseEntity(ex.message, HttpStatus.NOT_FOUND)
     }
 
+    @ExceptionHandler(WebExchangeBindException::class)
+    fun handleWebExchangeBindException(ex: WebExchangeBindException): ResponseEntity<String> {
+        return ResponseEntity(
+            ex.bindingResult.fieldErrors.map { it.defaultMessage }.joinToString("|"),
+            HttpStatus.BAD_REQUEST,
+        )
+    }
+
     @ExceptionHandler(IllegalArgumentException::class)
     fun handleValidationExceptions(ex: IllegalArgumentException): ResponseEntity<String> {
         return ResponseEntity(ex.message, HttpStatus.BAD_REQUEST)
     }
 
     @ExceptionHandler(Exception::class)
-    fun handleGlobalException(ex: Exception): ResponseEntity<String> {
+    fun handleRunTimeException(ex: Exception): ResponseEntity<String> {
         return ResponseEntity("An unexpected error occurred: ${ex.message}", HttpStatus.INTERNAL_SERVER_ERROR)
     }
 }


### PR DESCRIPTION
ExceptionHandler가 추가되면서 RequestBody 유효성 검사 실패를 500으로 리턴하는 문제를 수정했습니다.
이것 때문에 컨트롤러 테스트 코드가 실패했습니다.

WebMvc에서는 `MethodArgumentNotValidException`으로 잡았는데, WebFlux에서는 안잡히길래 헤맸네요.
WebFlux에서는 `WebExchangeBindException`으로 잡혀서 관련 핸들러 추가했습니다.

https://dev.gmarket.com/66